### PR TITLE
Unwrap code block lines within table cells

### DIFF
--- a/dist/validation/schema.js
+++ b/dist/validation/schema.js
@@ -103,6 +103,11 @@ function noBlocksWithinCell(opts, change, context) {
 
   nestedBlocks.forEach(function (block) {
     return block.nodes.forEach(function (grandChild) {
+      if (grandChild.type === "CODE_BLOCK_LINE") {
+        return grandChild.nodes.forEach(function (greatGrandChild) {
+          change.unwrapNodeByKey(greatGrandChild.key, { normalize: false });
+        });
+      }
       change.unwrapNodeByKey(grandChild.key, {
         normalize: false
       });

--- a/lib/validation/schema.js
+++ b/lib/validation/schema.js
@@ -100,6 +100,11 @@ function noBlocksWithinCell(opts, change, context) {
 
   nestedBlocks.forEach(block =>	
     block.nodes.forEach(grandChild => {	
+      if (grandChild.type === "CODE_BLOCK_LINE") {
+        return grandChild.nodes.forEach(greatGrandChild => {
+          change.unwrapNodeByKey(greatGrandChild.key, {normalize: false});
+        })
+      }
       change.unwrapNodeByKey(grandChild.key, {	
         normalize: false	
       });	


### PR DESCRIPTION
We received a report that some uploaded content from confluence (not synced) wasn't updating and wasn't opening in the editor. While investigating we discovered that the normalizer was getting into an infinite loop inside the table. The table cell had a `<pre>` tag which is specifically used for our code blocks but no `<code>` tag. Essentially the pre added the code tag, and then the table cell doesn't allow blocks (such as `<pre>`) and so it removed the pre tag, but the code tag remained. Then the code block normalizer added back the pre tag, and thus an infinite loop was formed. This will try to stop it when it's inside the table cell by removing the code tag first and then when it jumps out it also removes the pre tag, thus only leaving the text. While not ideal, we'd prefer to have the text also wrapped in a code snippet but this will at least allow the cards to open and then be edited to include the code snippet if they so desire.

Additionally, this isn't a new issue in our editor from the upgrade, this card should have never been able to open previously, and looking at the data, there is some strange discrepancy on the views in mode and the backend. So not sure if this card has ever been opened or not but this will help fix it if it does try to be opened in the future. (This was not customer reported)